### PR TITLE
Use LibLog for logging

### DIFF
--- a/CamundaClient.csproj
+++ b/CamundaClient.csproj
@@ -13,6 +13,10 @@
     <FileVersion>0.0.1.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="LibLog" Version="5.0.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 </Project>

--- a/CamundaEngineClient.cs
+++ b/CamundaEngineClient.cs
@@ -1,4 +1,5 @@
-﻿using CamundaClient.Service;
+﻿using CamundaClient.Logging;
+using CamundaClient.Service;
 using CamundaClient.Worker;
 using System;
 using System.Collections.Generic;
@@ -12,6 +13,7 @@ namespace CamundaClient
         public static string DEFAULT_URL = "http://localhost:8080/engine-rest/engine/default/";
         public static string COCKPIT_URL = "http://localhost:8080/camunda/app/cockpit/default/";
 
+        private static readonly ILog logger = LogProvider.For<CamundaEngineClient>();
         private IList<ExternalTaskWorker> _workers = new List<ExternalTaskWorker>();
         private CamundaClientHelper _camundaClientHelper;
 
@@ -48,7 +50,7 @@ namespace CamundaClient
 
             foreach (var taskWorkerInfo in externalTaskWorkers)
             {
-                Console.WriteLine($"Register Task Worker for Topic '{taskWorkerInfo.TopicName}'");
+                logger.Info("Register Task Worker for Topic '{TopicName}'", taskWorkerInfo.TopicName);
                 ExternalTaskWorker worker = new ExternalTaskWorker(ExternalTaskService, taskWorkerInfo);
                 _workers.Add(worker);
                 worker.StartWork();

--- a/Service/BpmnWorkflowService.cs
+++ b/Service/BpmnWorkflowService.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using CamundaClient.Logging;
 using CamundaClient.Requests;
 using System.Text;
 using Newtonsoft.Json.Serialization;
@@ -13,6 +14,8 @@ namespace CamundaClient.Service
 
     public class BpmnWorkflowService
     {
+        private static readonly ILog logger = LogProvider.For<BpmnWorkflowService>();
+
         private CamundaClientHelper helper;
 
         public BpmnWorkflowService(CamundaClientHelper client)
@@ -82,7 +85,7 @@ namespace CamundaClient.Service
             }
             else
             {
-                //Console.WriteLine("{0} ({1})", (int)response.StatusCode, response.ReasonPhrase);
+                logger.Debug("Received non-success status while loading process instance. Status: {StatusCode}; Reason: {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
                 throw new EngineException("Could not load process instances: " + response.ReasonPhrase);
             }
 

--- a/Service/ExternalTaskService.cs
+++ b/Service/ExternalTaskService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
+using CamundaClient.Logging;
 using CamundaClient.Requests;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Serialization;
@@ -13,6 +14,8 @@ namespace CamundaClient.Service
 
     public class ExternalTaskService
     {
+        private static readonly ILog logger = LogProvider.For<ExternalTaskService>();
+
         private CamundaClientHelper helper;
 
         public ExternalTaskService(CamundaClientHelper client)
@@ -69,7 +72,7 @@ namespace CamundaClient.Service
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.Message);
+                logger.Error(ex, "Exception while fetching and locking tasks.");
                 // TODO: Handle Exception, add back off
                 throw;
             }

--- a/Service/HumanTaskService.cs
+++ b/Service/HumanTaskService.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using CamundaClient.Logging;
 using CamundaClient.Requests;
 using Newtonsoft.Json.Serialization;
 
@@ -14,6 +15,8 @@ namespace CamundaClient.Service
 
     public class HumanTaskService
     {
+        private static readonly ILog logger = LogProvider.For<HumanTaskService>();
+
         private CamundaClientHelper helper;
 
         public HumanTaskService(CamundaClientHelper client)
@@ -37,7 +40,7 @@ namespace CamundaClient.Service
             }
             else
             {
-                //Console.WriteLine("{0} ({1})", (int)response.StatusCode, response.ReasonPhrase);
+                logger.Debug("Received non-success status while loading tasks. Status: {StatusCode}; Reason: {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
                 throw new EngineException("Could not load tasks: " + response.ReasonPhrase);
             }
 

--- a/Service/RepositoryService.cs
+++ b/Service/RepositoryService.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
+using CamundaClient.Logging;
 using CamundaClient.Requests;
 
 namespace CamundaClient.Service
@@ -15,6 +16,8 @@ namespace CamundaClient.Service
 
     public class RepositoryService
     {
+        private static readonly ILog logger = LogProvider.For<RepositoryService>();
+
         private CamundaClientHelper helper;
 
         public RepositoryService(CamundaClientHelper helper)
@@ -113,13 +116,12 @@ namespace CamundaClient.Service
                 // Read and add to Form for Deployment                
                 files.Add(FileParameter.FromManifestResource(thisExe, resource));
 
-                Console.WriteLine("Adding resource to deployment: " + resource);
+                logger.Info("Adding resource {Resource} to deployment", resource);
             }
 
             Deploy(thisExe.GetName().Name, files);
 
-            Console.WriteLine("Deployment to Camunda BPM succeeded.");
-
+            logger.Info("Deployment to Camunda BPM succeeded.");
         }
 
     }


### PR DESCRIPTION
[LibLog](https://github.com/damianh/LibLog) is a simple logging abstraction mechanism which allows log providers to be swapped without takin in an additional dependency. This should be a bit cleaner than writing to `Console.Out`.